### PR TITLE
Enabled named language tabs

### DIFF
--- a/marked.js
+++ b/marked.js
@@ -60,11 +60,17 @@ fs.readFile('./source/index.md', 'utf8', function (err, content) {
 
   for (var idx = 0; idx < tokens.length; idx++) {
     token = tokens[idx]
-    // console.log(token)
     if (token.type === 'list_item_start') {
       token = tokens[idx + 1].text
-      if (listName === 'language_tabs' && token === 'shell') {
-        token = 'bash'
+      if (listName === 'language_tabs' && token.indexOf('shell') > -1) {
+        token = token.replace('shell', 'bash')
+      }
+
+      if (listName === 'language_tabs') {
+        var lang = token
+        var langSplit = lang.split(':')
+        if (langSplit.length === 1) token = {name: langSplit[0], text: langSplit[0]}
+        if (langSplit.length === 2) token = {name: langSplit[0], text: langSplit[1]}
       }
       data[listName].push(token)
       idx += 2

--- a/source/index.html
+++ b/source/index.html
@@ -33,9 +33,9 @@
     <div class="tocify-wrapper">
       <img src="images/logo.png" />
         <div class="lang-selector">
-              <a href="#" data-language-name="bash">bash</a>
-              <a href="#" data-language-name="ruby">ruby</a>
-              <a href="#" data-language-name="python">python</a>
+              <a href="#" data-language-name="bash"> cURL</a>
+              <a href="#" data-language-name="ruby"> Ruby</a>
+              <a href="#" data-language-name="python"> Python</a>
         </div>
         <div class="search">
           <input type="text" class="search" id="input-search" placeholder="Search">
@@ -252,9 +252,9 @@ api.kittens.get(<span class="hljs-number">2</span>)
         </div>
       <div class="dark-box">
           <div class="lang-selector">
-              <a href="#" data-language-name="bash">bash</a>
-              <a href="#" data-language-name="ruby">ruby</a>
-              <a href="#" data-language-name="python">python</a>
+              <a href="#" data-language-name="bash"> cURL</a>
+              <a href="#" data-language-name="ruby"> Ruby</a>
+              <a href="#" data-language-name="python"> Python</a>
           </div>
       </div>
     </div>

--- a/source/index.md
+++ b/source/index.md
@@ -2,9 +2,9 @@
 title: API Reference
 
 language_tabs:
-  - bash
-  - ruby
-  - python
+  - bash: cURL
+  - ruby: Ruby
+  - python: Python
 
 toc_footers:
   - <a href='#'>Sign Up for a Developer Key</a>

--- a/source/layouts/layout.html
+++ b/source/layouts/layout.html
@@ -16,7 +16,7 @@
         $(function() {
           var langs = [];
           {{#each language_tabs}}
-            langs.push({{{str this}}});
+            langs.push({{{str this.name}}});
           {{/each}}          
           setupLanguages( langs );
         });
@@ -34,7 +34,7 @@
       <img src="images/logo.png" />
         <div class="lang-selector">
               {{#each language_tabs}}
-              <a href="#" data-language-name="{{this}}">{{this}}</a>
+              <a href="#" data-language-name="{{this.name}}">{{this.text}}</a>
               {{/each}}
         </div>
         <div class="search">
@@ -57,7 +57,7 @@
       <div class="dark-box">
           <div class="lang-selector">
               {{#each language_tabs}}
-              <a href="#" data-language-name="{{this}}">{{this}}</a>
+              <a href="#" data-language-name="{{this.name}}">{{this.text}}</a>
               {{/each}}
           </div>
       </div>


### PR DESCRIPTION
I have enabled the possibility to have „correct“ names for the language
tabs.
[Slate](https://github.com/tripit/slate/wiki/Customizing-the-Language-Ta
bs#language-tab-display-names)

> The language name that you use next to the code blocks must exactly
> match one of the Rouge supported languages. However, sometimes you want
> the language tab to list something else. For instance, you may want the
> shell language to appear in the language tab as "Curl".

Let's say your language tabs are like this:

``` md
language_tabs:
  - shell
  - ruby
  - python
```

You want the "shell" to say "cURL" instead. You can't just change all
instances of shell to cURL, since the syntax highlighter has no idea to
highlight cURL like a shell script. Instead, just change your
language_tabs to look like this:

``` md
language_tabs:
  - shell: cURL
  - ruby
  - python
```

You continue using shell next to your code blocks, but the language tab
now reads "cURL". You can also use this to make your language tabs have
nicer capitalization:

``` md
language_tabs:
  - shell: cURL
  - ruby: Ruby
  - python: Python
```

@jmanek I don't think that I'll need a direct contributor role. 😄  But thank you very much! And let's see what else I'll found to fix 😏 
