### PR TITLE
Create syntax-highlighting alias shell for bash

### DIFF
--- a/marked.js
+++ b/marked.js
@@ -31,6 +31,12 @@ marked.setOptions({
   }
 })
 
+// Create syntax-highlighting alias 'shell' for 'bash'
+var bash = highlight.getLanguage('bash')
+highlight.registerLanguage('shell', function (highlight) {
+  return bash
+})
+
 // Easier than changing Slate's js
 marked.defaults.langPrefix = 'highlight '
 
@@ -45,8 +51,6 @@ Handlebars.registerHelper('html', function (content) {
 fs.readFile('./source/index.md', 'utf8', function (err, content) {
   if (err) console.log(err)
 
-  // // marked doens't recognize "shell"?
-  content = content.replace(/``` shell/gm, '``` bash')
   content = content.split(/---/g)
 
   if (content.length === 1) {
@@ -62,9 +66,6 @@ fs.readFile('./source/index.md', 'utf8', function (err, content) {
     token = tokens[idx]
     if (token.type === 'list_item_start') {
       token = tokens[idx + 1].text
-      if (listName === 'language_tabs' && token.indexOf('shell') > -1) {
-        token = token.replace('shell', 'bash')
-      }
 
       if (listName === 'language_tabs') {
         var lang = token

--- a/source/index.html
+++ b/source/index.html
@@ -15,7 +15,7 @@
       <script>
         $(function() {
           var langs = [];
-            langs.push("bash");
+            langs.push("shell");
             langs.push("ruby");
             langs.push("python");
           setupLanguages( langs );
@@ -33,7 +33,7 @@
     <div class="tocify-wrapper">
       <img src="images/logo.png" />
         <div class="lang-selector">
-              <a href="#" data-language-name="bash"> cURL</a>
+              <a href="#" data-language-name="shell"> cURL</a>
               <a href="#" data-language-name="ruby"> Ruby</a>
               <a href="#" data-language-name="python"> Python</a>
         </div>
@@ -67,7 +67,7 @@ api = <span class="hljs-constant">Kittn::APIClient</span>.authorize!(<span class
 
 api = kittn.authorize(<span class="hljs-string">'meowmeowmeow'</span>)
 </code></pre>
-<pre><code class="highlight bash"><span class="hljs-comment"># With shell, you can just pass the correct header with each request</span>
+<pre><code class="highlight shell"><span class="hljs-comment"># With shell, you can just pass the correct header with each request</span>
 curl <span class="hljs-string">"api_endpoint_here"</span>
   -H <span class="hljs-string">"Authorization: meowmeowmeow"</span>
 </code></pre>
@@ -93,7 +93,7 @@ api.kittens.get
 api = kittn.authorize(<span class="hljs-string">'meowmeowmeow'</span>)
 api.kittens.get()
 </code></pre>
-<pre><code class="highlight bash">curl <span class="hljs-string">"http://example.com/api/kittens"</span>
+<pre><code class="highlight shell">curl <span class="hljs-string">"http://example.com/api/kittens"</span>
   -H <span class="hljs-string">"Authorization: meowmeowmeow"</span>
 </code></pre>
 <blockquote>
@@ -156,7 +156,7 @@ api.kittens.get(<span class="hljs-number">2</span>)
 api = kittn.authorize(<span class="hljs-string">'meowmeowmeow'</span>)
 api.kittens.get(<span class="hljs-number">2</span>)
 </code></pre>
-<pre><code class="highlight bash">curl <span class="hljs-string">"http://example.com/api/kittens/2"</span>
+<pre><code class="highlight shell">curl <span class="hljs-string">"http://example.com/api/kittens/2"</span>
   -H <span class="hljs-string">"Authorization: meowmeowmeow"</span>
 </code></pre>
 <blockquote>
@@ -252,7 +252,7 @@ api.kittens.get(<span class="hljs-number">2</span>)
         </div>
       <div class="dark-box">
           <div class="lang-selector">
-              <a href="#" data-language-name="bash"> cURL</a>
+              <a href="#" data-language-name="shell"> cURL</a>
               <a href="#" data-language-name="ruby"> Ruby</a>
               <a href="#" data-language-name="python"> Python</a>
           </div>

--- a/source/index.md
+++ b/source/index.md
@@ -2,7 +2,7 @@
 title: API Reference
 
 language_tabs:
-  - bash: cURL
+  - shell: cURL
   - ruby: Ruby
   - python: Python
 
@@ -43,7 +43,7 @@ import kittn
 api = kittn.authorize('meowmeowmeow')
 ```
 
-```bash
+```shell
 # With shell, you can just pass the correct header with each request
 curl "api_endpoint_here"
   -H "Authorization: meowmeowmeow"
@@ -79,7 +79,7 @@ api = kittn.authorize('meowmeowmeow')
 api.kittens.get()
 ```
 
-```bash
+```shell
 curl "http://example.com/api/kittens"
   -H "Authorization: meowmeowmeow"
 ```
@@ -138,7 +138,7 @@ api = kittn.authorize('meowmeowmeow')
 api.kittens.get(2)
 ```
 
-```bash
+```shell
 curl "http://example.com/api/kittens/2"
   -H "Authorization: meowmeowmeow"
 ```


### PR DESCRIPTION
This is more extensible later on if more language differences are noticed.

This comes from my port of slate to node (didn't know about your package when I wrote it), https://github.com/mermade/shins - there's some other ideas you might like to pinch there, such as using js-yaml to parse the markdown header, and node-sass for the scss.
