### PR TITLE
Correct license in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "url": "git+https://github.com/jessemanek/slate.git"
   },
   "author": "Jesse Manek",
-  "license": "ISC",
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/jessemanek/slate/issues"
   },


### PR DESCRIPTION
Correct as per LICENSE file and Slate's original licensing
